### PR TITLE
Update user display to show usernames

### DIFF
--- a/USER_MANAGEMENT.md
+++ b/USER_MANAGEMENT.md
@@ -1,0 +1,92 @@
+# User Management for OYE Time Tracker
+
+This document explains how to manage users in the OYE Time Tracker system to fix the user display issue where usernames were showing as "user[ID]" instead of actual names.
+
+## What Changed
+
+- **Added a `users` table** to store user information (user_id, username, display_name)
+- **Updated display logic** in three key places to show proper usernames instead of "user[ID]"
+- **Added fallback handling** - if a user is not found in the users table, it falls back to "user[ID]" format
+
+## Commands
+
+### View Active User IDs
+See which user IDs are currently in your time entries:
+```bash
+./oye-time-tracker active-users
+```
+
+### Populate Sample Users
+Add some sample users to get started:
+```bash
+./oye-time-tracker populate-users
+```
+
+### List All Users
+View all users currently in the database:
+```bash
+./oye-time-tracker list-users
+```
+
+### Add Individual User
+Add a specific user manually:
+```bash
+./oye-time-tracker add-user <user_id> <username> <display_name>
+```
+
+Example:
+```bash
+./oye-time-tracker add-user 1820471 "john.doe" "John Doe"
+```
+
+## Database Schema
+
+The new `users` table has the following structure:
+
+```sql
+CREATE TABLE users (
+    user_id INTEGER PRIMARY KEY,
+    username TEXT NOT NULL,
+    display_name TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+## How It Works
+
+1. **User Lookup**: When displaying user contributions, the system now looks up usernames from the `users` table
+2. **Fallback**: If a user is not found, it falls back to the old "user[ID]" format
+3. **Priority**: Display name is preferred over username, with user ID as final fallback
+
+## Typical Workflow
+
+1. **Check active users**: Run `./oye-time-tracker active-users` to see which user IDs are in your time entries
+2. **Add users**: Use the commands above to add proper usernames for those IDs
+3. **Test**: Generate a report to see usernames instead of "user[ID]"
+
+## Integration with External Systems
+
+If you're importing user data from another system (like TimeCamp, Slack, or HR systems), you can:
+
+1. Use the `UpsertUser()` function in your import scripts
+2. Call the user management functions programmatically
+3. Bulk import via SQL if needed
+
+## Example Output
+
+**Before (with user IDs):**
+```
+• Today: 5h 30m [user1820471: 3h 30m, user1721068: 2h 0m]
+```
+
+**After (with proper names):**
+```
+• Today: 5h 30m [John Smith: 3h 30m, Mary Johnson: 2h 0m]
+```
+
+## Troubleshooting
+
+- **Database connection issues**: Make sure your database environment variables are set correctly
+- **Users not showing**: Verify users exist with `./oye-time-tracker list-users`
+- **Still seeing user IDs**: The user might not be in the users table or there might be a database connection error (check logs)

--- a/slack_context_response.go
+++ b/slack_context_response.go
@@ -493,11 +493,24 @@ func (s *SlackAPIClient) formatSimpleTaskBlock(task TaskUpdateInfo) []Block {
 		}
 		sort.Ints(sortedUserIDs)
 		
+		// Get database connection for user name lookups
+		db, err := GetDB()
+		var userDisplayNames map[int]string
+		if err == nil {
+			userDisplayNames = GetAllUserDisplayNames(db, sortedUserIDs)
+		}
+		
 		for _, userID := range sortedUserIDs {
 			contrib := task.UserBreakdown[userID]
 			// Only show users who contributed time in the current period
 			if contrib.CurrentTime != "0h 0m" {
-				userContribs = append(userContribs, fmt.Sprintf("user%d: %s", userID, contrib.CurrentTime))
+				userName := fmt.Sprintf("user%d", userID) // fallback
+				if userDisplayNames != nil {
+					if displayName, exists := userDisplayNames[userID]; exists {
+						userName = displayName
+					}
+				}
+				userContribs = append(userContribs, fmt.Sprintf("%s: %s", userName, contrib.CurrentTime))
 			}
 		}
 		

--- a/slack_updates_utils.go
+++ b/slack_updates_utils.go
@@ -286,11 +286,24 @@ func formatSingleTaskBlock(task TaskUpdateInfo) Block {
 		}
 		sort.Ints(sortedUserIDs)
 		
+		// Get database connection for user name lookups
+		db, err := GetDB()
+		var userDisplayNames map[int]string
+		if err == nil {
+			userDisplayNames = GetAllUserDisplayNames(db, sortedUserIDs)
+		}
+		
 		for _, userID := range sortedUserIDs {
 			contrib := task.UserBreakdown[userID]
 			// Only show users who contributed time in the current period
 			if contrib.CurrentTime != "0h 0m" {
-				userContribs = append(userContribs, fmt.Sprintf("user%d: %s", userID, contrib.CurrentTime))
+				userName := fmt.Sprintf("user%d", userID) // fallback
+				if userDisplayNames != nil {
+					if displayName, exists := userDisplayNames[userID]; exists {
+						userName = displayName
+					}
+				}
+				userContribs = append(userContribs, fmt.Sprintf("%s: %s", userName, contrib.CurrentTime))
 			}
 		}
 		
@@ -464,11 +477,24 @@ func appendTaskTextMessage(builder *strings.Builder, task TaskUpdateInfo) {
 		}
 		sort.Ints(sortedUserIDs)
 		
+		// Get database connection for user name lookups
+		db, err := GetDB()
+		var userDisplayNames map[int]string
+		if err == nil {
+			userDisplayNames = GetAllUserDisplayNames(db, sortedUserIDs)
+		}
+		
 		for _, userID := range sortedUserIDs {
 			contrib := task.UserBreakdown[userID]
 			// Only show users who contributed time in the current period
 			if contrib.CurrentTime != "0h 0m" {
-				userContribs = append(userContribs, fmt.Sprintf("user%d: %s", userID, contrib.CurrentTime))
+				userName := fmt.Sprintf("user%d", userID) // fallback
+				if userDisplayNames != nil {
+					if displayName, exists := userDisplayNames[userID]; exists {
+						userName = displayName
+					}
+				}
+				userContribs = append(userContribs, fmt.Sprintf("%s: %s", userName, contrib.CurrentTime))
 			}
 		}
 		

--- a/user_management.go
+++ b/user_management.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+// PopulateUsers adds sample users to the database for testing
+func PopulateUsers() error {
+	logger := GetGlobalLogger()
+	
+	db, err := GetDB()
+	if err != nil {
+		return fmt.Errorf("failed to get database connection: %w", err)
+	}
+
+	// Sample users that might be common in the time entries
+	sampleUsers := []struct {
+		UserID      int
+		Username    string
+		DisplayName string
+	}{
+		{1820471, "john.smith", "John Smith"},
+		{1721068, "mary.johnson", "Mary Johnson"},
+		{2490949, "alex.wilson", "Alex Wilson"},
+		{1234567, "sarah.brown", "Sarah Brown"},
+		{9876543, "mike.davis", "Mike Davis"},
+	}
+
+	logger.Info("Adding sample users to the database...")
+
+	for _, user := range sampleUsers {
+		err := UpsertUser(db, user.UserID, user.Username, user.DisplayName)
+		if err != nil {
+			logger.Warnf("Failed to add user %d (%s): %v", user.UserID, user.Username, err)
+		} else {
+			logger.Infof("Added/updated user: %d - %s (%s)", user.UserID, user.DisplayName, user.Username)
+		}
+	}
+
+	logger.Info("User population completed")
+	return nil
+}
+
+// ListUsers shows all users in the database
+func ListUsers() error {
+	logger := GetGlobalLogger()
+	
+	db, err := GetDB()
+	if err != nil {
+		return fmt.Errorf("failed to get database connection: %w", err)
+	}
+
+	query := `SELECT user_id, username, display_name, created_at FROM users ORDER BY user_id`
+	rows, err := db.Query(query)
+	if err != nil {
+		return fmt.Errorf("failed to query users: %w", err)
+	}
+	defer rows.Close()
+
+	fmt.Println("Current users in database:")
+	fmt.Println("User ID  | Username      | Display Name  | Created At")
+	fmt.Println("---------|---------------|---------------|-------------------")
+
+	userCount := 0
+	for rows.Next() {
+		var userID int
+		var username, displayName, createdAt string
+		
+		err := rows.Scan(&userID, &username, &displayName, &createdAt)
+		if err != nil {
+			logger.Warnf("Failed to scan user row: %v", err)
+			continue
+		}
+
+		fmt.Printf("%-8d | %-13s | %-13s | %s\n", userID, username, displayName, createdAt[:19])
+		userCount++
+	}
+
+	if userCount == 0 {
+		fmt.Println("No users found in database")
+	} else {
+		fmt.Printf("\nTotal: %d users\n", userCount)
+	}
+
+	return nil
+}
+
+// AddUser adds a single user to the database
+func AddUser(userID int, username, displayName string) error {
+	logger := GetGlobalLogger()
+	
+	db, err := GetDB()
+	if err != nil {
+		return fmt.Errorf("failed to get database connection: %w", err)
+	}
+
+	err = UpsertUser(db, userID, username, displayName)
+	if err != nil {
+		return fmt.Errorf("failed to add user: %w", err)
+	}
+
+	logger.Infof("Successfully added/updated user: %d - %s (%s)", userID, displayName, username)
+	return nil
+}
+
+// GetActiveUserIDs returns a list of user IDs that have time entries
+func GetActiveUserIDs() ([]int, error) {
+	db, err := GetDB()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get database connection: %w", err)
+	}
+
+	query := `SELECT DISTINCT user_id FROM time_entries ORDER BY user_id`
+	rows, err := db.Query(query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query active user IDs: %w", err)
+	}
+	defer rows.Close()
+
+	var userIDs []int
+	for rows.Next() {
+		var userID int
+		err := rows.Scan(&userID)
+		if err != nil {
+			continue
+		}
+		userIDs = append(userIDs, userID)
+	}
+
+	return userIDs, nil
+}
+
+func init() {
+	// Add command line support for user management
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "populate-users":
+			if err := PopulateUsers(); err != nil {
+				fmt.Printf("Error populating users: %v\n", err)
+				os.Exit(1)
+			}
+		case "list-users":
+			if err := ListUsers(); err != nil {
+				fmt.Printf("Error listing users: %v\n", err)
+				os.Exit(1)
+			}
+		case "active-users":
+			userIDs, err := GetActiveUserIDs()
+			if err != nil {
+				fmt.Printf("Error getting active user IDs: %v\n", err)
+				os.Exit(1)
+			}
+			fmt.Println("Active user IDs from time entries:")
+			for _, userID := range userIDs {
+				fmt.Printf("- %d\n", userID)
+			}
+		case "add-user":
+			if len(os.Args) < 5 {
+				fmt.Println("Usage: ./oye-time-tracker add-user <user_id> <username> <display_name>")
+				os.Exit(1)
+			}
+			var userID int
+			fmt.Sscanf(os.Args[2], "%d", &userID)
+			username := os.Args[3]
+			displayName := os.Args[4]
+			if err := AddUser(userID, username, displayName); err != nil {
+				fmt.Printf("Error adding user: %v\n", err)
+				os.Exit(1)
+			}
+		}
+	}
+}


### PR DESCRIPTION
To resolve the display of `user[ID]` instead of usernames, a new user management system was implemented.

*   A `users` table was introduced in `db_setup.go` with `user_id`, `username`, and `display_name` fields.
    *   Functions `migrateUsersTable`, `createUsersTable`, `GetUserDisplayName`, `UpsertUser`, and `GetAllUserDisplayNames` were added to manage user data and retrieve display names.
*   Display logic was updated in `slack_updates_utils.go` (`formatSingleTaskBlock`, `appendTaskTextMessage`) and `slack_context_response.go` (`formatSimpleTaskBlock`).
    *   These functions now query the new `users` table to fetch `display_name` or `username` for user IDs.
    *   A fallback to the original `user[ID]` format is maintained if a user is not found in the database.
*   A new file, `user_management.go`, was created to provide command-line tools for user administration:
    *   `populate-users`: Adds sample users.
    *   `list-users`: Displays all stored users.
    *   `add-user`: Manually adds a single user.
    *   `active-users`: Lists user IDs present in time entries.
*   Documentation for the new user management system was added in `USER_MANAGEMENT.md`.

The system now prioritizes `display_name` over `username`, falling back to `user[ID]` if no entry exists.