### PR TITLE
Fix task update display issues

### DIFF
--- a/sync_time_entries_to_db.go
+++ b/sync_time_entries_to_db.go
@@ -518,7 +518,7 @@ SELECT
     COALESCE(db.total_duration, 0) AS day_before_duration
 FROM yesterday y
 FULL OUTER JOIN day_before db ON y.task_id = db.task_id AND y.user_id = db.user_id
-WHERE COALESCE(y.total_duration, 0) > 0 OR COALESCE(db.total_duration, 0) > 0;
+WHERE COALESCE(y.total_duration, 0) > 0;
 `
 
 	userRows, err := db.Query(userBreakdownQuery)
@@ -571,7 +571,7 @@ SELECT
 FROM tasks t
 LEFT JOIN yesterday y ON t.task_id = y.task_id
 LEFT JOIN day_before db ON t.task_id = db.task_id
-WHERE COALESCE(y.total_duration, 0) > 0 OR COALESCE(db.total_duration, 0) > 0;
+WHERE COALESCE(y.total_duration, 0) > 0;
 `
 	rows, err := db.Query(query)
 	if err != nil {
@@ -655,7 +655,7 @@ SELECT
     COALESCE(pw.total_duration, 0) AS previous_week_duration
 FROM current_week cw
 FULL OUTER JOIN previous_week pw ON cw.task_id = pw.task_id AND cw.user_id = pw.user_id
-WHERE COALESCE(cw.total_duration, 0) > 0 OR COALESCE(pw.total_duration, 0) > 0;
+WHERE COALESCE(cw.total_duration, 0) > 0;
 `
 
 	userRows, err := db.Query(userBreakdownQuery)
@@ -709,7 +709,7 @@ SELECT
 FROM tasks t
 LEFT JOIN current_week cw ON t.task_id = cw.task_id
 LEFT JOIN previous_week pw ON t.task_id = pw.task_id
-WHERE COALESCE(cw.total_duration, 0) > 0 OR COALESCE(pw.total_duration, 0) > 0;
+WHERE COALESCE(cw.total_duration, 0) > 0;
 `
 	rows, err := db.Query(query)
 	if err != nil {
@@ -800,7 +800,7 @@ SELECT
     COALESCE(pm.total_duration, 0) AS previous_month_duration
 FROM current_month cm
 FULL OUTER JOIN previous_month pm ON cm.task_id = pm.task_id AND cm.user_id = pm.user_id
-WHERE COALESCE(cm.total_duration, 0) > 0 OR COALESCE(pm.total_duration, 0) > 0;
+WHERE COALESCE(cm.total_duration, 0) > 0;
 `
 
 	userRows, err := db.Query(userBreakdownQuery)
@@ -854,7 +854,7 @@ SELECT
 FROM tasks t
 LEFT JOIN current_month cm ON t.task_id = cm.task_id
 LEFT JOIN previous_month pm ON t.task_id = pm.task_id
-WHERE COALESCE(cm.total_duration, 0) > 0 OR COALESCE(pm.total_duration, 0) > 0;
+WHERE COALESCE(cm.total_duration, 0) > 0;
 `
 	rows, err := db.Query(query)
 	if err != nil {


### PR DESCRIPTION
The issue of tasks displaying "0h 0m" for the current period was addressed in `sync_time_entries_to_db.go`.

The problem originated from SQL `WHERE` clauses that included tasks if they had any time worked in *either* the current period *or* the previous period. For example, `WHERE COALESCE(current_duration, 0) > 0 OR COALESCE(previous_duration, 0) > 0`.

The solution involved modifying these `WHERE` clauses to strictly filter for tasks with time worked *only* in the current period: `WHERE COALESCE(current_duration, 0) > 0`.

Changes were applied to:
*   `GetTaskTimeEntries` (daily updates): Both the main query and user breakdown query were updated to show tasks only if they had work yesterday.
*   `GetWeeklyTaskTimeEntries` (weekly updates): Both the main query and user breakdown query were updated to show tasks only if they had work this week.
*   `GetMonthlyTaskTimeEntries` (monthly updates): Both the main query and user breakdown query were updated to show tasks only if they had work this month.

As a result, reports now exclusively display tasks that were actively worked on within the specified time frame, providing cleaner and more relevant updates. Previous period durations are still shown for comparison for these relevant tasks.